### PR TITLE
(chore) Update travisCI node test version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '0.12'
+  - '6.0.0'
   
 before_script: 
   - 'npm update -g npm'


### PR DESCRIPTION
Closes #42.
Update to node test version 6.0.0.
