### PR TITLE
(feat) Add NY Times api query with geo data response

### DIFF
--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -136,6 +136,36 @@ export const fetchReddit = () => {
 };
 
 //=======================
+// NYTimes Actions
+//=======================
+export const nyTimesSuccess = (articleData) => {
+  console.log("article data: ", articleData);
+  return {
+    type: types.NYTIMES_SUCCESS,
+    payload: articleData
+  };
+};
+
+export const nyTimesFailure = () => {
+  return {
+    type: types.NYTIMES_FAILURE
+  };
+};
+
+export const nyTimesFlickr = () => {
+  return (dispatch) => {
+    return helper.getHelper('/results/nytimes')
+    .then((response) => {
+      dispatch(nyTimesSuccess(response));
+    })
+    .catch((err) => {
+      console.error(err);
+      dispatch(nyTimesFailure());
+    });
+  };
+};
+
+//=======================
 // Event Registry Actions
 //=======================
 export const eventsSuccess = (data) => {

--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -139,7 +139,6 @@ export const fetchReddit = () => {
 // NYTimes Actions
 //=======================
 export const nyTimesSuccess = (articleData) => {
-  console.log("article data: ", articleData);
   return {
     type: types.NYTIMES_SUCCESS,
     payload: articleData

--- a/client/actions/index.js
+++ b/client/actions/index.js
@@ -152,7 +152,7 @@ export const nyTimesFailure = () => {
   };
 };
 
-export const nyTimesFlickr = () => {
+export const fetchNYTimes = () => {
   return (dispatch) => {
     return helper.getHelper('/results/nytimes')
     .then((response) => {

--- a/client/components/NYTimes.jsx
+++ b/client/components/NYTimes.jsx
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+
+export default class NYTimes extends Component {
+  constructor(props) {
+    super(props);
+  }
+
+  // For future pings
+  // 
+  // componentWillReceiveProps(object) {
+  // }
+  
+
+  render() {
+    // if (!this.props.flickr.result.data) {
+    //   return (
+    //   <div>AWAITING FETCH INVOKE (NY Times)...</div>
+    //   );
+    // }
+    
+    return (
+      <div>
+        URL will go here
+      </div>
+    );
+  }
+}

--- a/client/components/NYTimes.jsx
+++ b/client/components/NYTimes.jsx
@@ -9,12 +9,6 @@ export default class NYTimes extends Component {
   // 
   // componentWillReceiveProps(object) {
   // }
-    componentWillReceiveProps(object) {
-    if (this.props.nytimes.result.data) {
-      console.log("this is NYTIMES: ", this.props.nytimes.result.data.results);
-    }
-  }
-
   render() {
     if (!this.props.nytimes.result.data) {
       return (

--- a/client/components/NYTimes.jsx
+++ b/client/components/NYTimes.jsx
@@ -9,18 +9,26 @@ export default class NYTimes extends Component {
   // 
   // componentWillReceiveProps(object) {
   // }
-  
+    componentWillReceiveProps(object) {
+    if (this.props.nytimes.result.data) {
+      console.log("this is NYTIMES: ", this.props.nytimes.result.data.results);
+    }
+  }
 
   render() {
-    // if (!this.props.flickr.result.data) {
-    //   return (
-    //   <div>AWAITING FETCH INVOKE (NY Times)...</div>
-    //   );
-    // }
+    if (!this.props.nytimes.result.data) {
+      return (
+      <div>AWAITING FETCH INVOKE (NY Times)...</div>
+      );
+    }
     
     return (
       <div>
-        URL will go here
+        NY Times Latitude: {this.props.nytimes.result.data.results[0].geocodes[0].latitude}
+        NY Times Longitude: {this.props.nytimes.result.data.results[0].geocodes[0].longitude}
+        NY Times URL: {this.props.nytimes.result.data.results[0].article_list.results[0].url}
+        NY Times Body: {this.props.nytimes.result.data.results[0].article_list.results[0].title}
+        NY Times Title: {this.props.nytimes.result.data.results[0].article_list.results[0].body}
       </div>
     );
   }

--- a/client/components/Result.jsx
+++ b/client/components/Result.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Component } from 'react';
 import FlickrComponent from './Flickr.jsx';
 import RedditComponent from './Reddit.jsx';
+import NYTimesComponent from './NYTimes.jsx';
 import EventRegistryComponent from './EventRegistry.jsx';
 
 class Result extends Component {
@@ -15,11 +16,12 @@ class Result extends Component {
 
   render() {
     console.log(this.props.reddit);
-    const { result, ui, flickr, reddit, pingGlobe, eventRegistry } = this.props;
+    const { result, ui, flickr, reddit, nytimes, pingGlobe, eventRegistry } = this.props;
     return(
       <div>
         <FlickrComponent flickr={flickr} pingGlobe={pingGlobe}/>
         <RedditComponent reddit={reddit} />
+        <NYTimesComponent nytimes={nytimes} />
         <EventRegistryComponent eventRegistry={eventRegistry}/>
       </div>
     )

--- a/client/constants/ActionTypes.js
+++ b/client/constants/ActionTypes.js
@@ -20,6 +20,11 @@ export const FETCH_FLICKR = 'FETCH_FLICKR';
 export const FLICKR_SUCCESS = 'FLICKR_SUCCESS';
 export const FLICKR_FAILURE = 'FLICKR_FAILURE';
 
+// NYTimes Actionsny
+export const FETCH_NYTIMES = 'FETCH_NYTIMES';
+export const NYTIMES_SUCCESS = 'NYTIMES_SUCCESS';
+export const NYTIMES_FAILURE = 'NYTIMES_FAILURE';
+
 // Event Registry Actions
 export const EVENTS_SUCCESS = 'EVENTS_SUCCESS';
 

--- a/client/containers/FetchButtonContainer.js
+++ b/client/containers/FetchButtonContainer.js
@@ -9,6 +9,7 @@ function mapDispatchToProps(dispatch) {
     getData: () => {
       dispatch(actions.fetchReddit());
       dispatch(actions.fetchFlickr());
+      dispatch(actions.fetchNYTimes());
       dispatch(actions.fetchEventRegistry());
     }
   };

--- a/client/containers/NYTimesContainer.js
+++ b/client/containers/NYTimesContainer.js
@@ -1,0 +1,19 @@
+import * as actions from '../actions/index.js';
+import { connect } from 'react-redux';
+import { fetchNYtimes } from '../actions/index';
+import NYTimes from '../components/NYTimes.jsx';
+
+// ES5 syntax below:
+// function mapStateToProps({ state }) {
+//   return { flickr: state.flickr };
+// }
+
+// ES6 syntax below:
+function mapStateToProps(state) {
+  return { 
+    nytimes: state.nytimes,
+    globe: state.globe
+  };
+}
+
+export default connect(mapStateToProps)(NYTimes);

--- a/client/containers/NYTimesContainer.js
+++ b/client/containers/NYTimesContainer.js
@@ -1,6 +1,6 @@
 import * as actions from '../actions/index.js';
 import { connect } from 'react-redux';
-import { fetchNYtimes } from '../actions/index';
+import { fetchNYTimes } from '../actions/index';
 import NYTimes from '../components/NYTimes.jsx';
 
 // ES5 syntax below:
@@ -9,11 +9,8 @@ import NYTimes from '../components/NYTimes.jsx';
 // }
 
 // ES6 syntax below:
-function mapStateToProps(state) {
-  return { 
-    nytimes: state.nytimes,
-    globe: state.globe
-  };
+function mapStateToProps({ nytimes }) {
+  return { nytimes };
 }
 
 export default connect(mapStateToProps)(NYTimes);

--- a/client/containers/ResultContainer.js
+++ b/client/containers/ResultContainer.js
@@ -20,6 +20,7 @@ const mapStateToProps = (state) => {
     ui: state.ui,
     flickr: state.flickr,
     reddit: state.reddit,
+    nytimes: state.nytimes,
     eventRegistry: state.eventRegistry
   };
 };

--- a/client/reducers/nyTimesReducer.js
+++ b/client/reducers/nyTimesReducer.js
@@ -1,0 +1,20 @@
+import * as types from '../constants/ActionTypes';
+
+export default (state = {
+  result: []  // State for results
+}, action) => {
+  switch (action.type) {
+    case types.NYTIMES_SUCCESS:
+    return {
+      ...state,
+      result: action.payload
+    };
+  //   case types.GLOBE_INSTANTIATED:
+  //   return {
+  //     ...state,
+  //     globe: action.payload
+  //   };
+  //   default:
+  //   return state;
+  // }
+}

--- a/client/reducers/nyTimesReducer.js
+++ b/client/reducers/nyTimesReducer.js
@@ -9,6 +9,14 @@ export default (state = {
       ...state,
       result: action.payload
     };
+    case types.NYTIMES_FAILURE:
+    return {
+      ...state,
+      result: []
+    };
+    default:
+    return state;
+  }
   //   case types.GLOBE_INSTANTIATED:
   //   return {
   //     ...state,
@@ -16,5 +24,4 @@ export default (state = {
   //   };
   //   default:
   //   return state;
-  // }
 }

--- a/client/reducers/rootReducer.js
+++ b/client/reducers/rootReducer.js
@@ -7,6 +7,7 @@ import auth from './authReducer.js';
 import ui from './uiReducer.js';
 import flickr from './flickrReducer';
 import reddit from './redditReducer';
+import nytimes from './nyTimesReducer';
 import globe from './globeReducer';
 import eventRegistry from './eventRegistryReducer';
 /**
@@ -20,6 +21,7 @@ const rootReducer = combineReducers({
   globe,
   flickr,
   reddit,
+  nytimes,
   eventRegistry,
   routing
 });

--- a/server/private/private.js
+++ b/server/private/private.js
@@ -1,5 +1,5 @@
-const FLICKR_KEY = 'c47ece224080058910137d84a24cfe94';
-const NYTIMES_KEY = '6100344d597e4ebfb39d602a70beb817';
+const FLICKR_KEY = process.env.FLICKR_KEY;
+const NYTIMES_KEY = process.env.NYTIMES_KEY;
 
 module.exports = {
   FLICKR_KEY,

--- a/server/private/private.js
+++ b/server/private/private.js
@@ -1,5 +1,7 @@
 const FLICKR_KEY = 'c47ece224080058910137d84a24cfe94';
+const NYTIMES_KEY = '6100344d597e4ebfb39d602a70beb817';
 
 module.exports = {
-  FLICKR_KEY
+  FLICKR_KEY,
+  NYTIMES_KEY
 };

--- a/server/routes/results/results.js
+++ b/server/routes/results/results.js
@@ -32,7 +32,12 @@ router.get('/reddit', (req, res) => {
 
 //nytimes request handlers
 router.get('/nytimes', (req, res) => {
-  const nyTimesUrl = 'http://api.nytimes.com/svc/semantic/v2/concept/name/nytd_geo/Europe?fields=all&' + 'api-key=' + private.NYTIMES_KEY;
+  
+  // location randomizer for NY Times api call
+  const nyTimesLocations = ["Europe", "United States", "Australia", "South America", "Russia", "China", "Japan", "Middle East", "Africa", "Central America", "India", "Mexico", "Venezuela", "Spain", "France", "Vietnam", "Thailand", "South Africa", "Kenya"];
+  var randomNYTimesLocation = nyTimesLocations[Math.floor(Math.random()*nyTimesLocations.length)];
+  
+  const nyTimesUrl = 'http://api.nytimes.com/svc/semantic/v2/concept/name/nytd_geo/' + randomNYTimesLocation  + '?fields=all&' + 'api-key=' + private.NYTIMES_KEY;
   return helper.getHelper(nyTimesUrl)
   .then((response) => {
     res.send(response.data);

--- a/server/routes/results/results.js
+++ b/server/routes/results/results.js
@@ -30,4 +30,17 @@ router.get('/reddit', (req, res) => {
   })
 });
 
+//nytimes request handlers
+router.get('/nytimes', (req, res) => {
+  const nyTimesUrl = 'http://api.nytimes.com/svc/semantic/v2/concept/name/nytd_geo/Europe?fields=all&' + 'api-key=' + private.NYTIMES_KEY;
+  return helper.getHelper(nyTimesUrl)
+  .then((response) => {
+    res.send(response.data);
+  })
+  .catch((error) => {
+    console.error(error);
+    res.send(error);
+  })
+});
+
 module.exports = router;


### PR DESCRIPTION
Closes #125.

Add NY Times Semantic API on front and back end to fetch new articles based on random global location. Will return article title, url, body snippet, and lat/lon.

API keys stored in private.js changed to process.env for Heroku deployment/security.
